### PR TITLE
Keep screen on while playing

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,6 +4,7 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-sdk android:minSdkVersion="8" />
 
     <application

--- a/src/org/nushackers/Minicraft/MinicraftActivity.java
+++ b/src/org/nushackers/Minicraft/MinicraftActivity.java
@@ -3,7 +3,9 @@ package org.nushackers.Minicraft;
 import com.mojang.ld22.Game;
 
 import android.app.Activity;
+import android.content.Context;
 import android.os.Bundle;
+import android.os.PowerManager;
 import android.util.DisplayMetrics;
 import android.view.Window;
 import android.view.WindowManager;
@@ -11,6 +13,8 @@ public class MinicraftActivity extends Activity {
 	/** Called when the activity is first created. */
 	
 	Game game;
+	private PowerManager.WakeLock wakelock = null;
+	
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -38,6 +42,10 @@ public class MinicraftActivity extends Activity {
 		pad.setJoystickListener(game.getInput());
 		pad.setButton1Listener(game.getInput().atkListener);
 		pad.setButton2Listener(game.getInput().menuListener);
+		
+		PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
+		wakelock = pm.newWakeLock(PowerManager.SCREEN_BRIGHT_WAKE_LOCK, "Minicraft");
+		wakelock.acquire();
 		game.start();
 
 	}
@@ -45,5 +53,7 @@ public class MinicraftActivity extends Activity {
 	protected void onPause() {
 		super.onPause();
 		game.stop();
+		if(wakelock != null && wakelock.isHeld())
+			wakelock.release();
 	}
 }


### PR DESCRIPTION
Acquire a WakeLock to keep the screen on while playing, and release it when the game loses focus.  This is important when using a control method other than the touchscreen.
